### PR TITLE
VertexPos and VertexPosUv -> inline instead of constexpr

### DIFF
--- a/common/rendering/IRenderModel.hpp
+++ b/common/rendering/IRenderModel.hpp
@@ -24,14 +24,14 @@ namespace Render
 			float boneWeights[4]{};
 		};
 
-		constexpr Vertex VertexPos( Vec3 position )
+		inline Vertex VertexPos( Vec3 position )
 		{
 			Vertex v;
 			v.position = position;
 			return v;
 		}
 
-		constexpr Vertex VertexPosUv( Vec3 position, Vec2 uv )
+		inline Vertex VertexPosUv( Vec3 position, Vec2 uv )
 		{
 			Vertex v;
 			v.position = position;


### PR DESCRIPTION
Currently this prevents compilation, since Vec2/3/4 operators aren't `constexpr` yet. May be useful to look into that.